### PR TITLE
Dependencies and attribution

### DIFF
--- a/Muzei.hs
+++ b/Muzei.hs
@@ -14,12 +14,13 @@ import qualified Data.ByteString.Lazy.Char8 as BL
 import GHC.Generics (Generic)
 
 data ArtMetaData = ArtMetaData {
-      byline     :: String, -- "Author, YEAR"
-      detailsUri :: String, -- link to wikiart
-      imageUri   :: String, -- link to image
-      nextTime   :: String, -- time stamp
-      thumbUri   :: String, -- link to thumbnail image
-      title      :: String  -- painting title
+      attribution :: String, -- "wikiart.org"
+      byline      :: String, -- "Author, YEAR"
+      detailsUri  :: String, -- link to wikiart
+      imageUri    :: String, -- link to image
+      nextTime    :: String, -- time stamp
+      thumbUri    :: String, -- link to thumbnail image
+      title       :: String  -- painting title
     } deriving (Show, Generic)
 
 instance FromJSON ArtMetaData

--- a/MuzeiDesktop.cabal
+++ b/MuzeiDesktop.cabal
@@ -60,7 +60,7 @@ executable MuzeiDesktop
   other-extensions:    DeriveGeneric, OverloadedStrings
   
   -- Other library packages from which modules are imported.
-  build-depends:       base >=4.7 && <4.8, hdaemonize >=0.5 && <0.6, download-curl >=0.1 && <0.2, aeson >=0.8 && <0.9, split >=0.2 && <0.3, directory >=1.2 && <1.3, process >=1.2 && <1.3, bytestring >=0.10 && <0.11
+  build-depends:       base >=4.9, hdaemonize >=0.5, download-curl >=0.1, aeson >=0.8, split >=0.2, directory >=1.2, process >=1.2, bytestring >=0.10
   
   -- Directories containing source files.
   -- hs-source-dirs:      


### PR DESCRIPTION
Script doesn't work now that the Muzei endpoint includes an attribution value.

Also opens up the tops of the dependencies to new versions.
I needed this to run the script on my system (which has a newer base installed globally).
